### PR TITLE
Pin IPFS for tests to v0.4.23

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_PASSWORD: letmein
 
   ipfs:
-    image: ipfs/go-ipfs
+    image: ipfs/go-ipfs:v0.4.23
     ports:
       - '5001:5001'
 


### PR DESCRIPTION
Graph node won't work with IPFS v0.5 right now. See https://github.com/graphprotocol/graph-node/issues/1617