### PR TITLE
Num outcomes

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -31,7 +31,7 @@ type Condition @entity {
   oracle: Bytes!
   questionId: Bytes!
   question: Question
-  outcomeSlotCount: BigInt!
+  outcomeSlotCount: Int!
   resolutionTimestamp: BigInt
   payouts: [BigDecimal!]
   fixedProductMarketMakers: [FixedProductMarketMaker!]! @derivedFrom(field: "conditions")
@@ -49,6 +49,7 @@ type FixedProductMarketMaker @entity {
 
   collateralVolume: BigInt!
   outcomeTokenAmounts: [BigInt!]!
+  outcomeSlotCount: Int
   liquidityParameter: BigInt!
 
   lastActiveDay: BigInt!

--- a/src/ConditionalTokensMapping.template.ts
+++ b/src/ConditionalTokensMapping.template.ts
@@ -12,7 +12,7 @@ export function handleConditionPreparation(event: ConditionPreparation): void {
     condition.question = event.params.questionId.toHexString();
   }
 
-  condition.outcomeSlotCount = event.params.outcomeSlotCount;
+  condition.outcomeSlotCount = event.params.outcomeSlotCount.toI32();
   condition.save();
 }
 

--- a/src/FPMMDeterministicFactoryMapping.template.ts
+++ b/src/FPMMDeterministicFactoryMapping.template.ts
@@ -44,10 +44,11 @@ export function handleFixedProductMarketMakerCreation(event: FixedProductMarketM
       return;
     }
 
-    outcomeTokenCount *= condition.outcomeSlotCount.toI32();
+    outcomeTokenCount *= condition.outcomeSlotCount;
     conditionIdStrs[i] = conditionIdStr;
   }
   fixedProductMarketMaker.conditions = conditionIdStrs;
+  fixedProductMarketMaker.outcomeSlotCount = outcomeTokenCount;
   fixedProductMarketMaker.indexedOnQuestion = false;
 
   if(conditionIdStrs.length == 1) {

--- a/test/omen-subgraph.js
+++ b/test/omen-subgraph.js
@@ -140,6 +140,7 @@ describe('Omen subgraph', function() {
           fee
           collateralVolume
           outcomeTokenAmounts
+          outcomeSlotCount
           liquidityParameter
           indexedOnQuestion
           condition {
@@ -184,6 +185,7 @@ describe('Omen subgraph', function() {
       fixedProductMarketMaker.outcomeTokenAmounts.should.eql(
         chainOutcomeTokenAmounts.map(v => v.toString()),
       );
+      fixedProductMarketMaker.outcomeSlotCount.should.equal(outcomeSlotCount);
       fixedProductMarketMaker.liquidityParameter.should.equal(
         nthRoot(
           chainOutcomeTokenAmounts.reduce((acc, amount) => acc.mul(amount), toBN(1)),
@@ -356,9 +358,11 @@ describe('Omen subgraph', function() {
 
     const { condition, question } = await querySubgraph(`{
       condition(id: "${conditionId}") {
+        oracle
         question {
           title
         }
+        outcomeSlotCount
         resolutionTimestamp
         payouts
       }
@@ -366,7 +370,9 @@ describe('Omen subgraph', function() {
         conditions { id }
       }
     }`);
+    condition.oracle.should.equal(oracle.address.toLowerCase());
     condition.question.should.eql({ title: 'なに!?' });
+    condition.outcomeSlotCount.should.equal(outcomeSlotCount);
     should.not.exist(condition.resolutionTimestamp);
     should.not.exist(condition.payouts);
 


### PR DESCRIPTION
Resolves #7 

Adds `outcomeSlotCount`, which is the # of outcome tokens being traded by the FPMM, and `numOutcomes`, which is the # of outcomes parsed out of the question data from Realitio.

Edit: `numOutcomes` caused an exception to occur somehow, so that commit has been removed. Maybe should investigate later if that field should exist as well.